### PR TITLE
Fix menu read eof

### DIFF
--- a/menufile.c
+++ b/menufile.c
@@ -88,12 +88,16 @@ void get_menuitems(void)
 	if (menufile != NULL)
 	{
 		num_menuitems = 0;
-		while ((!feof(menufile)) && (!ferror(menufile)) && (num_menuitems < MAX_MENUITEMS))
+		while (num_menuitems < MAX_MENUITEMS)
 		{
 			char menustr[STR_SIZE] = "";
-			if (fgets(menustr, STR_SIZE, menufile) == NULL) // we already checked for EOF above
+			if (fgets(menustr, STR_SIZE, menufile) == NULL)
 			{
-				err("error reading menu file");
+			    int readerror = ferror(menufile);
+				if (readerror != 0)
+				{
+					err("error reading menu file: %d", readerror);
+				}
 				break;
 			}
 			if (strlen(menustr) != 0)

--- a/menufile.c
+++ b/menufile.c
@@ -93,7 +93,7 @@ void get_menuitems(void)
 			char menustr[STR_SIZE] = "";
 			if (fgets(menustr, STR_SIZE, menufile) == NULL)
 			{
-			    int readerror = ferror(menufile);
+				int readerror = ferror(menufile);
 				if (readerror != 0)
 				{
 					err("error reading menu file: %d", readerror);


### PR DESCRIPTION
Apparently I don't know how feof and fgets interplay.

The man page says

```
       fgets()  returns s on success, and NULL on error or when end of file oc‐
       curs while no characters have been read.
```
however, so I dunno...

I was seeing "error reading menu file" messages on successful menurc reads.