### PR TITLE
Don't leave empty space on title-less windows

### DIFF
--- a/new.c
+++ b/new.c
@@ -205,7 +205,7 @@ static void init_position(Client *c)
 	{
 		get_mouse_position(&mousex, &mousey);
 		c->x = mousex;
-		c->y = mousey + BARHEIGHT();
+		c->y = mousey + TITLEHEIGHT(c);
 		gravitate(c, REMOVE_GRAVITY);
 	}
 }
@@ -218,7 +218,7 @@ static void reparent(Client *c)
 	pattr.background_pixel = empty_col.pixel;
 	pattr.border_pixel = border_col.pixel;
 	pattr.event_mask = ChildMask|ButtonPressMask|ExposureMask|EnterWindowMask;
-	c->frame = XCreateWindow(dsply, root, c->x, c->y - BARHEIGHT(), c->width, c->height + BARHEIGHT(), BORDERWIDTH(c), DefaultDepth(dsply, screen), CopyFromParent, DefaultVisual(dsply, screen), CWOverrideRedirect|CWBackPixel|CWBorderPixel|CWEventMask, &pattr);
+	c->frame = XCreateWindow(dsply, root, c->x, c->y - TITLEHEIGHT(c), c->width, c->height + TITLEHEIGHT(c), BORDERWIDTH(c), DefaultDepth(dsply, screen), CopyFromParent, DefaultVisual(dsply, screen), CWOverrideRedirect|CWBackPixel|CWBorderPixel|CWEventMask, &pattr);
 
 #ifdef SHAPE
 	if (shape)
@@ -232,7 +232,7 @@ static void reparent(Client *c)
 	XSelectInput(dsply, c->window, ColormapChangeMask|PropertyChangeMask);
 	XSetWindowBorderWidth(dsply, c->window, 0);
 	XResizeWindow(dsply, c->window, c->width, c->height);
-	XReparentWindow(dsply, c->window, c->frame, 0, BARHEIGHT());
+	XReparentWindow(dsply, c->window, c->frame, 0, TITLEHEIGHT(c));
 
 	send_config(c);
 }

--- a/windowlab.h
+++ b/windowlab.h
@@ -145,6 +145,13 @@ typedef struct PropMwmHints
 #define BORDERWIDTH(c) (DEF_BORDERWIDTH)
 #endif
 
+// title height accessor to handle hints/no hints
+#ifdef MWM_HINTS
+#define TITLEHEIGHT(c) ((c)->has_title ? BARHEIGHT() : 0)
+#else
+#define TITLEHEIGHT(c) (BARHEIGHT())
+#endif
+
 // bar height
 #ifdef XFT
 #define BARHEIGHT() (xftfont->ascent + xftfont->descent + 2*SPACE + 2)


### PR DESCRIPTION
I noticed this just testing that compilation still works with `-DMWM_HINTS` after my changes.

Side note: this means we lose any handle to move title-less windows by.

## Before

(My "empty" color i `#f0f` for debugging purposes.)

<img width="1476" height="622" alt="before" src="https://github.com/user-attachments/assets/67dd9289-135a-4d55-88dc-b759a820e35d" />

## After
<img width="1392" height="640" alt="after" src="https://github.com/user-attachments/assets/9fc1ce4e-e140-4b3f-a051-a121776a6f46" />

