### PR TITLE
Revert "Don't leave empty space on title-less windows (#9)"

### DIFF
--- a/new.c
+++ b/new.c
@@ -205,7 +205,7 @@ static void init_position(Client *c)
 	{
 		get_mouse_position(&mousex, &mousey);
 		c->x = mousex;
-		c->y = mousey + TITLEHEIGHT(c);
+		c->y = mousey + BARHEIGHT();
 		gravitate(c, REMOVE_GRAVITY);
 	}
 }
@@ -218,7 +218,7 @@ static void reparent(Client *c)
 	pattr.background_pixel = empty_col.pixel;
 	pattr.border_pixel = border_col.pixel;
 	pattr.event_mask = ChildMask|ButtonPressMask|ExposureMask|EnterWindowMask;
-	c->frame = XCreateWindow(dsply, root, c->x, c->y - TITLEHEIGHT(c), c->width, c->height + TITLEHEIGHT(c), BORDERWIDTH(c), DefaultDepth(dsply, screen), CopyFromParent, DefaultVisual(dsply, screen), CWOverrideRedirect|CWBackPixel|CWBorderPixel|CWEventMask, &pattr);
+	c->frame = XCreateWindow(dsply, root, c->x, c->y - BARHEIGHT(), c->width, c->height + BARHEIGHT(), BORDERWIDTH(c), DefaultDepth(dsply, screen), CopyFromParent, DefaultVisual(dsply, screen), CWOverrideRedirect|CWBackPixel|CWBorderPixel|CWEventMask, &pattr);
 
 #ifdef SHAPE
 	if (shape)
@@ -232,7 +232,7 @@ static void reparent(Client *c)
 	XSelectInput(dsply, c->window, ColormapChangeMask|PropertyChangeMask);
 	XSetWindowBorderWidth(dsply, c->window, 0);
 	XResizeWindow(dsply, c->window, c->width, c->height);
-	XReparentWindow(dsply, c->window, c->frame, 0, TITLEHEIGHT(c));
+	XReparentWindow(dsply, c->window, c->frame, 0, BARHEIGHT());
 
 	send_config(c);
 }

--- a/windowlab.h
+++ b/windowlab.h
@@ -145,13 +145,6 @@ typedef struct PropMwmHints
 #define BORDERWIDTH(c) (DEF_BORDERWIDTH)
 #endif
 
-// title height accessor to handle hints/no hints
-#ifdef MWM_HINTS
-#define TITLEHEIGHT(c) ((c)->has_title ? BARHEIGHT() : 0)
-#else
-#define TITLEHEIGHT(c) (BARHEIGHT())
-#endif
-
 // bar height
 #ifdef XFT
 #define BARHEIGHT() (xftfont->ascent + xftfont->descent + 2*SPACE + 2)


### PR DESCRIPTION
Reverts fabjan/windowlab#9

That opened up a can of worms. Resizing got weird, which was fixable by using `TITLEHEIGHT(c)` in more places, but trying to add moving back in was not elegant.