### PR TITLE
Make MWM hints work in 64 bit builds

### DIFF
--- a/new.c
+++ b/new.c
@@ -149,9 +149,6 @@ void make_new_client(Window w)
 	redraw_taskbar();
 }
 
-/* This one does *not* free the data coming back from Xlib; it just
- * sends back the pointer to what was allocated. */
-
 #ifdef MWM_HINTS
 static Bool get_mwm_hints(Window w, PropMwmHints *hints)
 {
@@ -189,6 +186,7 @@ static Bool get_mwm_hints(Window w, PropMwmHints *hints)
 	hints->decorations = (CARD32)data[2];
 	hints->inputMode = (INT32)data[3];
 	hints->status = (CARD32)data[4];
+	XFree(data);
 	return True;
 }
 #endif

--- a/new.c
+++ b/new.c
@@ -177,7 +177,7 @@ static Bool get_mwm_hints(Window w, PropMwmHints *hints)
 	}
 	if (items_read < PROP_MWM_HINTS_ELEMENTS)
 	{
-		err("hints property too small for window 0x%x (misssing %d of %d elements)", w, (PROP_MWM_HINTS_ELEMENTS - items_read), PROP_MWM_HINTS_ELEMENTS);
+		err("hints property too small for window 0x%x (missing %d of %d elements)", w, (PROP_MWM_HINTS_ELEMENTS - items_read), PROP_MWM_HINTS_ELEMENTS);
 		return False;
 	}
 	


### PR DESCRIPTION
I noticed WindowLab was reading the wrong values from `_MOTIF_WM_HINTS` in my setup.

I'm convinced passing a struct with 32 bit fields will not be properly filled in when `XGetWindowProperty` says `actual_format_return` is 32, see its man page.

To fix this I supply an `unsigned long` "array" pointer instead for data, and assign from it to the hints struct.