### PR TITLE
Stop grabbing scroll wheel "buttons"

### DIFF
--- a/events.c
+++ b/events.c
@@ -566,7 +566,7 @@ static void handle_enter_event(XCrossingEvent *e)
 		c = find_client(e->window, FRAME);
 		if (c != NULL)
 		{
-			XGrabButton(dsply, AnyButton, AnyModifier, c->frame, False, ButtonMask, GrabModeSync, GrabModeSync, None, None);
+			XGrabButton(dsply, 1, AnyModifier, c->frame, False, ButtonMask, GrabModeSync, GrabModeSync, None, None);
 		}
 	}
 }


### PR DESCRIPTION
Grabbing all mouse buttons seems to make scrolling not work in GTK apps (or at least Gnome Terminal, Nemo, Xfce Terminal on my machine).

Turns out the scroll wheel is a mouse button (or four).

This is a breaking change but who cares. The WindowLab docs state that you use the left mouse button to resize windows. It does not specify how to move windows but mouse 1 makes a lot of sense. The only mention of any other mouse button is right click for the task bar menu.